### PR TITLE
Detail画面の簡易作成

### DIFF
--- a/src/components/RecordIndex.js
+++ b/src/components/RecordIndex.js
@@ -31,7 +31,9 @@ export default class RecordList extends React.Component {
         </View>
         <Button
           title="詳細"
-          onPress={() => this.props.navigation.navigate('RecordDetail')}
+          onPress={() =>
+            this.props.navigation.navigate('RecordDetail', {record})
+          }
         />
       </View>
     );

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -12,7 +12,7 @@ class HomeScreen extends React.Component {
         <Heading name="記録一覧" />
         <Button
           title="Let's Record!"
-          onPress={() => this.props.navigation.navigate('Post')}
+          onPress={() => this.props.navigation.navigate('Post', {id: 1234})}
         />
         <RecordItems
           navigation={this.props.navigation}

--- a/src/screens/PostScreen.js
+++ b/src/screens/PostScreen.js
@@ -86,6 +86,7 @@ export default class PostScreen extends React.Component {
         <Title />
         <Heading name="記録する" />
         <View>
+          <Text>{this.props.route.params.id}</Text>
           <TextInput
             placeholder="今日のトレーニングはどうだった？"
             value={this.state.comment}

--- a/src/screens/RecordScreen.js
+++ b/src/screens/RecordScreen.js
@@ -6,7 +6,73 @@ export default class RecordScreen extends React.Component {
     return (
       <View>
         <Text>記録詳細</Text>
+        <View style={styles.wrapperStyle}>
+          <View style={styles.commentArea}>
+            <Text>{this.props.route.params.record.comment}</Text>
+          </View>
+          <View style={styles.eventArea}>
+            {this.props.route.params.record.event.map(data => {
+              return (
+                <View>
+                  <Text>{data.name}</Text>
+                  <View>
+                    {data.set.map(item => {
+                      return (
+                        <Text>
+                          {item.weight} x {item.rep} x {item.set}
+                        </Text>
+                      );
+                    })}
+                  </View>
+                </View>
+              );
+            })}
+          </View>
+          <View style={styles.datetimeArea}>
+            <Text style={styles.datetimeStyle}>
+              {this.props.route.params.record.created_at}
+            </Text>
+          </View>
+        </View>
       </View>
     );
   }
 }
+
+const styles = {
+  wrapperStyle: {
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    padding: 20,
+    margin: 10,
+    borderWidth: 2,
+    borderColor: '#FB9508',
+    borderRadius: 5,
+  },
+  commentArea: {
+    marginBottom: 10,
+  },
+  eventArea: {
+    padding: 10,
+    borderTopWidth: 1,
+    borderTopColor: '#000',
+  },
+  imageStyle: {
+    height: 300,
+    flex: 1,
+    width: null,
+  },
+  textStyle: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  datetimeArea: {
+    padding: 5,
+  },
+  datetimeStyle: {
+    fontSize: 12,
+    fontWeight: '300',
+    textAlign: 'right',
+    marginTop: 15,
+  },
+};


### PR DESCRIPTION
Navigationでパラメーターをページ遷移先へ渡すことができた。
react-navigationのバージョンによって、パラメーターの取得方法が違うことを発見できたおかげでハマリを解決。
https://stackoverflow.com/questions/61126610/typeerror-this-props-navigation-getparam-is-not-a-function-while-passing-parame